### PR TITLE
Added configuration to use compressed apt indexes.

### DIFF
--- a/12.04.4/Dockerfile
+++ b/12.04.4/Dockerfile
@@ -14,7 +14,9 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/no-cache \
 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/no-cache \
 	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/02compress-indexes
 
 # enable the universe ?
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list

--- a/12.10/Dockerfile
+++ b/12.10/Dockerfile
@@ -14,7 +14,9 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/no-cache \
 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/no-cache \
 	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/02compress-indexes
 
 # enable the universe ?
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list

--- a/13.04/Dockerfile
+++ b/13.04/Dockerfile
@@ -14,7 +14,9 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/no-cache \
 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/no-cache \
 	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/02compress-indexes
 
 # enable the universe ?
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list

--- a/13.10/Dockerfile
+++ b/13.10/Dockerfile
@@ -14,7 +14,9 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/no-cache \
 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/no-cache \
 	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/02compress-indexes
 
 # enable the universe ?
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list

--- a/14.04/Dockerfile
+++ b/14.04/Dockerfile
@@ -14,7 +14,9 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/no-cache \
 	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/no-cache \
 	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/02compress-indexes
 
 # enable the universe ?
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list


### PR DESCRIPTION
It reduces the size of the images using gzip compression for the files
in the folder /var/lib/apt/lists.
Fixes https://github.com/tianon/docker-brew-ubuntu-core/issues/1
