### PR TITLE
Making images for docker even smaller

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -52,14 +52,14 @@ RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	\
 	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
 	\
-	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes \
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes ; \
 
 # delete all the apt list files since they're big and get stale quickly
-rm -rf /var/lib/apt/lists/* \
+rm -rf /var/lib/apt/lists/* ; \
 # this forces "apt-get update" in dependent images, which is also good
 
 # enable the universe
-sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
+sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list ; \
 
 # upgrade packages for now, since the tarballs aren't updated frequently enough
 apt-get update && apt-get dist-upgrade -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hello,
 This is my first public pull request, so I am sorry if something wrong,
 I checked Dockerfile for minimal ubuntu images and found that were created images betweem scratch final with junk removed at the end of Dockerfile,
 Thus lets glue all RUN commands to avoid keeping junk in a middle images.

Thanks,
