### PR TITLE
Ensure that running 'systemd-detect-virt' shows 'docker'

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -92,6 +92,10 @@ RUN rm -rf /var/lib/apt/lists/*
 # enable the universe
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
+# make systemd-detect-virt return "docker"
+# See: https://github.com/systemd/systemd/blob/aa0c34279ee40bce2f9681b496922dedbadfca19/src/basic/virt.c#L434
+echo 'docker' > /run/systemd/container
+
 # overwrite this with 'CMD []' in a dependent Dockerfile
 CMD ["/bin/bash"]
 EOF

--- a/update.sh
+++ b/update.sh
@@ -94,7 +94,7 @@ RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
 # make systemd-detect-virt return "docker"
 # See: https://github.com/systemd/systemd/blob/aa0c34279ee40bce2f9681b496922dedbadfca19/src/basic/virt.c#L434
-echo 'docker' > /run/systemd/container
+RUN echo 'docker' > /run/systemd/container
 
 # overwrite this with 'CMD []' in a dependent Dockerfile
 CMD ["/bin/bash"]


### PR DESCRIPTION
In the Ubuntu docker image, let's set /run/systemd/container
to 'docker' to ensure that users are able to detect their
underlying environment accurately.