### PR TITLE
Use multi stage build to clear artifacts and reduce image size #90

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -50,7 +50,7 @@ for v in "${versions[@]}"; do
 	)
 
 	cat > "$v/Dockerfile" <<EOF
-FROM scratch
+FROM scratch as builder
 ADD $thisTar /
 EOF
 
@@ -98,6 +98,14 @@ RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 # make systemd-detect-virt return "docker"
 # See: https://github.com/systemd/systemd/blob/aa0c34279ee40bce2f9681b496922dedbadfca19/src/basic/virt.c#L434
 RUN mkdir -p /run/systemd && echo 'docker' > /run/systemd/container
+
+EOF
+
+	cat >> "$v/Dockerfile" <<'EOF'
+
+FROM scratch
+
+COPY --from=builder / /
 
 # overwrite this with 'CMD []' in a dependent Dockerfile
 CMD ["/bin/bash"]


### PR DESCRIPTION
Suggestion by @pranas: https://github.com/tianon/docker-brew-ubuntu-core/issues/90#issuecomment-355129413

It reduces the image size from 112MB to 86MB.