### PR TITLE
Squash newly built layers

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -120,7 +120,7 @@ if [ "$arch" = "$hostArch" ]; then
 			echo >&2 "warning: $v/Dockerfile does not exist; skipping $v"
 			continue
 		fi
-		( set -x; docker build -t "$repo:$v" "$v" )
+		( set -x; docker build --squash -t "$repo:$v" "$v" )
 		serial="$(awk -F '=' '$1 == "SERIAL" { print $2; exit }' "$v/build-info.txt")"
 		if [ "$serial" ]; then
 			( set -x; docker tag "$repo:$v" "$repo:$v-$serial" )


### PR DESCRIPTION
I eagerly prepared this and only afterwards found #90, #119, docker-library/official-images#3383 and docker-library/official-images#3334.

Anyway, this was supposed to propose using the experimental `--squash` flag introduced in Docker 1.13.0 (see [the release notes](https://github.com/moby/moby/releases/tag/v1.13.0) or moby/moby#22641) when building images. I realize there might be a better solution eventually but perfect is the enemy of good and changing it now doesn't prevent changing it again later.

Rebuilding images from commit 727813ecdf4a3d46bc1fb0bf479cebd76b462fed), this is the impact on size:

|  | Size without `--squash` | Size with `--squash` |
|---|---:|---:|
| 14.04 | 223 MB | 183 MB |
| 16.04 | 112 MB | ~86 MB |
| 18.04 | 79 MB | ~69 MB |

This shouldn't matter to most registries as they'll hopefully deduplicate content. The desired effect for me is reducing the five layers to a single layer which has a lot of impact when interacting with a registry as each layer causes a series of HTTP requests.

I realize this will properly be closed and that's fine although I would be happy to see it merged even if support is partial. 