### PR TITLE
Adjust "lists-deletion" code to be xenial-specific now that bionic+ are fixed

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -54,6 +54,21 @@ FROM scratch
 ADD $thisTar /
 EOF
 
+	if [ "$v" = 'xenial' ]; then
+		cat >> "$v/Dockerfile" <<'EOF'
+# delete all the apt list files since they're big and get stale quickly
+RUN rm -rf /var/lib/apt/lists/*
+# this forces "apt-get update" in dependent images, which is also good
+# (see also https://bugs.launchpad.net/cloud-images/+bug/1699913)
+EOF
+	else
+		cat >> "$v/Dockerfile" <<'EOF'
+# verify that the APT lists files do not exist
+RUN [ -z "$(apt-get indextargets)" ]
+# (see https://bugs.launchpad.net/cloud-images/+bug/1699913)
+EOF
+	fi
+
 	cat >> "$v/Dockerfile" <<'EOF'
 
 # a few minor docker-specific tweaks
@@ -86,11 +101,6 @@ RUN set -xe \
 	\
 # https://github.com/docker/docker/blob/9a9fc01af8fb5d98b8eec0740716226fadb3735c/contrib/mkimage/debootstrap#L134-L151
 	&& echo 'Apt::AutoRemove::SuggestsImportant "false";' > /etc/apt/apt.conf.d/docker-autoremove-suggests
-
-# delete all the apt list files since they're big and get stale quickly
-RUN rm -rf /var/lib/apt/lists/*
-# this forces "apt-get update" in dependent images, which is also good
-# (see also https://bugs.launchpad.net/cloud-images/+bug/1699913)
 
 # make systemd-detect-virt return "docker"
 # See: https://github.com/systemd/systemd/blob/aa0c34279ee40bce2f9681b496922dedbadfca19/src/basic/virt.c#L434


### PR DESCRIPTION
I've verified this across all supported suites for `amd64`; I'm assuming there's not enough architecture building variance to be worth testing other architectures too?