### PR TITLE
do not let stray directories confuse generate-stackbrew-library.sh quite so much

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -36,8 +36,8 @@ for archMap in "${archMaps[@]}"; do
 	archCommits[$arch]="$commit"
 done
 
-versions=( */ )
-versions=( "${versions[@]%/}" )
+versions=( */alias )
+versions=( "${versions[@]%/alias}" )
 
 cat <<-EOH
 # see https://partner-images.canonical.com/core/


### PR DESCRIPTION
This seems to fix the problem Phil had in my testing.