### PR TITLE
Add explicit supported arches for Trusty

### DIFF
--- a/trusty/arches
+++ b/trusty/arches
@@ -1,0 +1,6 @@
+amd64
+arm64
+armhf
+i386
+ppc64el
+s390x


### PR DESCRIPTION
Commit 70af633e877ec40fc80b94a1ed1da60fd19913c1 added explicit arches for each suite/version.

This was after Trusty was removed so to restore Trusty fully explicit arches are required there too.