### PR TITLE
Remove s390x from Trusty supported arches

### DIFF
--- a/trusty/arches
+++ b/trusty/arches
@@ -3,4 +3,3 @@ arm64
 armhf
 i386
 ppc64el
-s390x


### PR DESCRIPTION
s390x is not a supported arch for Trusty