### PR TITLE
Stop building i386 images for focal.

### DIFF
--- a/focal/arches
+++ b/focal/arches
@@ -1,6 +1,5 @@
 amd64
 arm64
 armhf
-i386
 ppc64el
 s390x


### PR DESCRIPTION
As of this week, the only packages building for focal on i386 are those
intended to support existing i386 binaries running on amd64 systems and
as such there are no interesting packages to install in a docker i386
container.