### PR TITLE
Add Ubuntu 20.10 Groovy as rolling release

### DIFF
--- a/rolling
+++ b/rolling
@@ -1,1 +1,1 @@
-focal
+groovy


### PR DESCRIPTION
In preparation for Ubuntu 20.10 Groovy release later today make groovy the rolling release.

latest -> lts (defined by "latest" file)
rolling -> most recent release (defined by "rolling" file)
devel- > development series (defined by querying http://archive.ubuntu.com/ubuntu/dists/devel/Release)