### PR TITLE
Move bionic, focal, groovy and hirsute to OCI tarballs

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,7 @@ for v in "${versions[@]}"; do
 	fi
 
 	case "$v" in
-		bionic | focal | groovy | hirsute | trusty | xenial)
+		trusty | xenial)
 			thisTarBase="ubuntu-$v-core-cloudimg-$arch"
 			thisTar="$thisTarBase-root.tar.gz"
 			baseUrl="https://partner-images.canonical.com/core/$v/current"

--- a/verify.sh
+++ b/verify.sh
@@ -27,7 +27,7 @@ arch="$(cat arch 2>/dev/null || true)"
 
 for v in "${versions[@]}"; do
 	case "$v" in
-		bionic | focal | groovy | hirsute | trusty | xenial)
+		trusty | xenial)
 			thisTarBase="ubuntu-$v-core-cloudimg-$arch"
 			thisTar="$thisTarBase-root.tar.gz"
 			sumTypes=( sha256 sha1 md5 )


### PR DESCRIPTION
This is a follow up on 26b6ae75425961 . There are now tarballs on
https://partner-images.canonical.com/oci/ also for bionic, focal,
groovy and hirsute so use theses new tarballs.