### PR TITLE
arch: add riscv64 images

### DIFF
--- a/focal/arches
+++ b/focal/arches
@@ -2,4 +2,5 @@ amd64
 arm64
 armhf
 ppc64el
+riscv64
 s390x

--- a/groovy/arches
+++ b/groovy/arches
@@ -2,4 +2,5 @@ amd64
 arm64
 armhf
 ppc64el
+riscv64
 s390x

--- a/hirsute/arches
+++ b/hirsute/arches
@@ -2,4 +2,5 @@ amd64
 arm64
 armhf
 ppc64el
+riscv64
 s390x

--- a/impish/arches
+++ b/impish/arches
@@ -2,4 +2,5 @@ amd64
 arm64
 armhf
 ppc64el
+riscv64
 s390x


### PR DESCRIPTION
Ubuntu now generates riscv64 images for Ubuntu 20.04 LTS (Focal) and
newer releases.