### PR TITLE
Add vendor and support labels to Xenial

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -110,6 +110,10 @@ EOF
 			;;
 	esac
 
+	if [ -f "$v/Dockerfile.append" ]; then
+		cat "$v/Dockerfile.append" >>"$v/Dockerfile"
+	fi
+
 	toVerify+=( "$v" )
 done
 

--- a/xenial/Dockerfile.append
+++ b/xenial/Dockerfile.append
@@ -1,0 +1,4 @@
+LABEL org.opencontainers.image.vendor="Canonical Ltd."
+LABEL org.opencontainers.image.version=16.04
+LABEL com.canonical.support.end-date=2021-04-30
+LABEL com.canonical.support.info=https://ubuntu.com/security/docker-images


### PR DESCRIPTION
As said in ebd5245, this is a proof-of-concept of support metadata in OCI
annotations. Ultimately, we want to engage with community and settle on either
com.docker or org.opencontainers.image namespace.

/cc @valentincanonical @toabctl