### PR TITLE
update.sh: Fix manifest filename

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -94,8 +94,8 @@ EOF
 			;;
 
 		*)
-			thisTarBase="ubuntu-$v-oci-$arch"
-			thisTar="$thisTarBase-root.tar.gz"
+			thisTarBase="ubuntu-$v-oci-$arch-root"
+			thisTar="$thisTarBase.tar.gz"
 			baseUrl="https://partner-images.canonical.com/oci/$v/current"
 			(
 				cd "$v"


### PR DESCRIPTION
The filename of published .manifest has changed to be similar to .tar.gz
sometime around 2022-06-11. Previously it was:

  ubuntu-kinetic-oci-arm64-root.tar.gz
  ubuntu-kinetic-oci-arm64.manifest

Currently it is

  ubuntu-kinetic-oci-arm64-root.tar.gz
  ubuntu-kinetic-oci-arm64-root.manifest